### PR TITLE
Clean up a missed API call

### DIFF
--- a/src/oldas/article_ids.py
+++ b/src/oldas/article_ids.py
@@ -75,7 +75,7 @@ class ArticleIDs(OldList[ArticleID]):
         continuation: str | None = ""
         while True:
             result = await session.get(
-                "/stream/items/ids", s=str(state), n=10_000, c=continuation, **filters
+                "stream/items/ids", s=str(state), n=10_000, c=continuation, **filters
             )
             for article_id in (
                 ArticleID.from_json(article_id)


### PR DESCRIPTION
Just another / at the start that isn't needed. It doesn't cause a problem, but it's good to clean it up.